### PR TITLE
Add regex for two common bots

### DIFF
--- a/cfg/regx.txt
+++ b/cfg/regx.txt
@@ -54,3 +54,7 @@ vk.com\\/thenosok
 O.?M.?E.?G.?A.?T.?R.?O.?N.?I.?C.?
 irc\.myg0t\.gg:6667#myg0t
 Debug User./\.
+Good shot mate!
+\(\d\)Good shot mate!
+www\.myg0t\.win
+\(\d\)www\.myg0t\.win


### PR DESCRIPTION
myg0t.win is the second most common I think after omegatronic and Good shot mate is another mic spam and sniper hack bot. Both rename themselves by prepending a digit so I've included regexes for that too.