### PR TITLE
Add friends in current server indicator

### DIFF
--- a/src/gui.rs
+++ b/src/gui.rs
@@ -548,6 +548,7 @@ fn render_players_internal(ui: &mut Ui, state: &mut State) {
                         &state.settings.user,
                         true,
                         !state.settings.steamapi_key.is_empty(),
+                        state.server.get_player_party_color(player),
                     ) {
                         action = Some((returned_action, player));
                     }
@@ -565,6 +566,7 @@ fn render_players_internal(ui: &mut Ui, state: &mut State) {
                         &state.settings.user,
                         true,
                         !state.settings.steamapi_key.is_empty(),
+                        state.server.get_player_party_color(player),
                     ) {
                         action = Some((returned_action, player));
                     }

--- a/src/gui/player_windows.rs
+++ b/src/gui/player_windows.rs
@@ -230,6 +230,7 @@ pub fn recent_players_window() -> PersistentWindow<State> {
                                     &state.settings.user,
                                     false,
                                     !state.settings.steamapi_key.is_empty(),
+                                    None
                                 ) {
                                     action = Some((returned_action, player));
                                 }

--- a/src/gui/player_windows.rs
+++ b/src/gui/player_windows.rs
@@ -190,7 +190,7 @@ pub fn edit_player_window(mut record: PlayerRecord) -> PersistentWindow<State> {
 
                 // Render player info if they are in the server
                 if let Some(player) = state.server.get_players().get(&record.steamid) {
-                    player.render_account_info(ui);
+                    player.render_account_info(ui, None);
                 }
             });
 

--- a/src/server/parties.rs
+++ b/src/server/parties.rs
@@ -1,0 +1,130 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use std::hash::{DefaultHasher, Hash, Hasher};
+
+use crate::player::{steamid_64_to_32, Player, Steamid32};
+
+const COLOR_PALETTE: [egui::Color32; 21] = [
+    egui::Color32::from_rgb(230, 25, 75),
+    egui::Color32::from_rgb(60, 180, 75),
+    egui::Color32::from_rgb(255, 225, 25),
+    egui::Color32::from_rgb(0, 130, 200),
+    egui::Color32::from_rgb(245, 130, 48),
+    egui::Color32::from_rgb(145, 30, 180),
+    egui::Color32::from_rgb(70, 240, 240),
+    egui::Color32::from_rgb(240, 50, 230),
+    egui::Color32::from_rgb(210, 245, 60),
+    egui::Color32::from_rgb(250, 190, 212),
+    egui::Color32::from_rgb(0, 128, 128),
+    egui::Color32::from_rgb(220, 190, 255),
+    egui::Color32::from_rgb(170, 110, 40),
+    egui::Color32::from_rgb(255, 250, 200),
+    egui::Color32::from_rgb(128, 0, 0),
+    egui::Color32::from_rgb(170, 255, 195),
+    egui::Color32::from_rgb(128, 128, 0),
+    egui::Color32::from_rgb(255, 215, 180),
+    egui::Color32::from_rgb(0, 0, 128),
+    egui::Color32::from_rgb(128, 128, 128),
+    egui::Color32::from_rgb(255, 255, 255),
+];
+
+pub struct Parties{
+    players: Vec<Steamid32>,
+    friend_connections: HashMap<Steamid32, HashSet<Steamid32>>,
+    parties: Vec<HashSet<Steamid32>>,
+}
+
+impl Parties {
+    pub fn new() -> Parties {
+        Parties{
+            players: Vec::new(),
+            friend_connections: HashMap::new(),
+            parties: Vec::new(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.players.clear();
+        //self.friend_connections.clear();
+        self.parties.clear();
+    }
+
+    pub fn update(&mut self, player_map: &HashMap<Steamid32, Player>){
+        self.players.clear();
+        for p in player_map.keys() {
+            self.players.push(p.clone());
+        }
+
+        for p in player_map.values() {
+            if let Some(Ok(acif)) = &p.account_info {
+                if let Some(Ok(friends)) = &acif.friends {
+                    for f in friends {
+                        let id = steamid_64_to_32(&f.steamid).unwrap();
+                        if self.players.contains(&id){
+                            self.add_friend(&p.steamid32, &id);
+                        }
+                    }
+                }
+            }
+        }
+
+        self.find_parties();
+    }
+
+    fn find_parties(&mut self){
+        self.parties.clear();
+        if self.players.is_empty() {
+            return;
+        }
+        let mut remaining_players = self.players.clone();
+
+        let mut handled: HashSet<Steamid32> = HashSet::new();
+        let mut queue: VecDeque<Steamid32> = VecDeque::new();
+
+        while !remaining_players.is_empty() {
+            queue.push_back(remaining_players.pop().unwrap());
+            let mut party: HashSet<Steamid32> = HashSet::new();
+
+            while !queue.is_empty() {
+                let p = queue.pop_front().unwrap();
+                party.insert(p.clone());
+                handled.insert(p.clone());
+                
+                if let Some(friends) = self.friend_connections.get(&p) {
+                    friends.iter().filter(|f|!handled.contains(f.clone())).for_each(|f|queue.push_back(f.clone()));
+                }
+            }
+            if party.len() > 1{
+                self.parties.push(party);
+            }
+        }
+    }
+
+    fn add_friend(&mut self, user: &String, friend: &String){
+        if let Some(set) = self.friend_connections.get_mut(user){
+            set.insert(friend.clone());
+        } else {
+            self.friend_connections.insert(user.clone(), HashSet::from([friend.clone()]));
+        }
+
+        if let Some(set) = self.friend_connections.get_mut(friend){
+            set.insert(user.clone());
+        } else {
+            self.friend_connections.insert(friend.clone(), HashSet::from([user.clone()]));
+        }
+    }
+
+    pub fn get_parties(&self) -> &Vec<HashSet<Steamid32>> {
+        &self.parties
+    }
+
+    pub fn get_player_party_color(&self, p: &Player) -> Option<egui::Color32> {
+        for i in 0..self.parties.len(){
+            let party = self.parties.get(i).unwrap();
+            if party.contains(&p.steamid32){
+                return Some(COLOR_PALETTE[(i%COLOR_PALETTE.len()) as usize]);
+            }
+        }
+        None
+    }
+}

--- a/src/server/player.rs
+++ b/src/server/player.rs
@@ -268,7 +268,7 @@ impl Player {
         // information to show (i.e. notes or stolen name notification)
         if (allow_steamapi || !self.notes.is_empty() || self.stolen_name) && !menu_open {
             header.response.on_hover_ui(|ui| {
-                self.render_account_info(ui);
+                self.render_account_info(ui, party_color);
                 self.render_notes(ui);
             });
         }
@@ -330,7 +330,7 @@ impl Player {
     }
 
     /// Renders a view of the player's steam account info
-    pub fn render_account_info(&self, ui: &mut Ui) {
+    pub fn render_account_info(&self, ui: &mut Ui, party_color: Option<Color32>) {
         if let Some(info_request) = &self.account_info {
             match info_request {
                 Ok(info) => {
@@ -412,6 +412,13 @@ impl Player {
                                         bans.DaysSinceLastBan
                                     ))
                                     .color(Color32::RED),
+                                );
+                            }
+
+                            if let Some(c) = party_color {
+                                ui.label(
+                                    RichText::new("■ This player has friends in the server")
+                                    .color(c),
                                 );
                             }
                         });

--- a/src/server/player.rs
+++ b/src/server/player.rs
@@ -116,6 +116,7 @@ impl Player {
         user: &str,
         allow_kick: bool,
         allow_steamapi: bool,
+        party_color: Option<Color32>,
     ) -> Option<UserAction> {
         static mut CONTEXT_MENU_OPEN: Option<String> = None;
 
@@ -270,6 +271,11 @@ impl Player {
                 self.render_account_info(ui);
                 self.render_notes(ui);
             });
+        }
+
+        // Party Indicator
+        if let Some(col_party) = party_color {
+            ui.label(RichText::new("■").color(col_party));
         }
 
         // Cheater, Bot and Joining labels

--- a/src/steamapi.rs
+++ b/src/steamapi.rs
@@ -67,7 +67,7 @@ pub fn create_api_thread(key: String) -> (Sender<String>, AccountInfoReceiver) {
                             let bans = bans.unwrap();
 
                             // Friends
-                            let friends = if summary.communityvisibilitystate != 3 {
+                            let friends = if summary.communityvisibilitystate == 3 {
                                 Some(steam_api::get_friends_list(&steamid, &key))
                             } else {
                                 None


### PR DESCRIPTION
This PR adds little indicators to be able to see which players are friends on steam.
![image](https://github.com/Bash-09/tf2-bot-kicker-gui/assets/20463817/2e293b5f-dde1-4fe8-98d8-40e1609ddbc4)
This makes it easier to identify friends of cheaters who might try to stop a votekick.
